### PR TITLE
App Configuration Config 4.0 Review Changes

### DIFF
--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/ConfigurationClientCustomizer.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/ConfigurationClientCustomizer.java
@@ -8,7 +8,7 @@ import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 /**
  * Creates Custom CustomClientBuilder for connecting to Azure App Configuration.
  */
-public interface ConfigurationClientBuilderSetup {
+public interface ConfigurationClientCustomizer {
 
     /**
      * Updates the ConfigurationClientBuilder for connecting to the given App Configuration.

--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/AppConfigurationReplicaClientsBuilder.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/AppConfigurationReplicaClientsBuilder.java
@@ -24,7 +24,7 @@ import com.azure.core.http.policy.RetryPolicy;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.spring.cloud.config.AppConfigurationCredentialProvider;
-import com.azure.spring.cloud.config.ConfigurationClientBuilderSetup;
+import com.azure.spring.cloud.config.ConfigurationClientCustomizer;
 import com.azure.spring.cloud.config.implementation.pipline.policies.BaseAppConfigurationPolicy;
 import com.azure.spring.cloud.config.implementation.properties.ConfigStore;
 import com.azure.spring.cloud.core.provider.ClientOptionsProvider;
@@ -60,7 +60,7 @@ public class AppConfigurationReplicaClientsBuilder extends ConfigurationClientBu
 
     private AppConfigurationCredentialProvider tokenCredentialProvider;
 
-    private ConfigurationClientBuilderSetup clientProvider;
+    private ConfigurationClientCustomizer clientProvider;
 
     private boolean isDev = false;
 
@@ -106,7 +106,7 @@ public class AppConfigurationReplicaClientsBuilder extends ConfigurationClientBu
     /**
      * @param clientProvider the clientProvider to set
      */
-    public void setClientProvider(ConfigurationClientBuilderSetup clientProvider) {
+    public void setClientProvider(ConfigurationClientCustomizer clientProvider) {
         this.clientProvider = clientProvider;
     }
 

--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/config/AppConfigurationAutoConfiguration.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/config/AppConfigurationAutoConfiguration.java
@@ -29,7 +29,7 @@ public class AppConfigurationAutoConfiguration {
      */
     @Configuration
     @ConditionalOnClass(RefreshEndpoint.class)
-    static class AppConfigurationWatchAutoConfiguration {
+    public static class AppConfigurationWatchAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean

--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/config/AppConfigurationBootstrapConfiguration.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/config/implementation/config/AppConfigurationBootstrapConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.azure.spring.cloud.config.AppConfigurationCredentialProvider;
-import com.azure.spring.cloud.config.ConfigurationClientBuilderSetup;
+import com.azure.spring.cloud.config.ConfigurationClientCustomizer;
 import com.azure.spring.cloud.config.KeyVaultCredentialProvider;
 import com.azure.spring.cloud.config.KeyVaultSecretProvider;
 import com.azure.spring.cloud.config.SecretClientBuilderSetup;
@@ -109,7 +109,7 @@ public class AppConfigurationBootstrapConfiguration {
         clientBuilder.setTokenCredentialProvider(
             context.getBeanProvider(AppConfigurationCredentialProvider.class).getIfAvailable());
         clientBuilder
-            .setClientProvider(context.getBeanProvider(ConfigurationClientBuilderSetup.class)
+            .setClientProvider(context.getBeanProvider(ConfigurationClientCustomizer.class)
                 .getIfAvailable());
 
         clientBuilder.setIsKeyVaultConfigured(keyVaultClientFactory.isConfigured());

--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/config/implementation/AppConfigurationReplicaClientBuilderTest.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/config/implementation/AppConfigurationReplicaClientBuilderTest.java
@@ -29,7 +29,7 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
 import com.azure.data.appconfiguration.ConfigurationServiceVersion;
 import com.azure.spring.cloud.config.AppConfigurationCredentialProvider;
-import com.azure.spring.cloud.config.ConfigurationClientBuilderSetup;
+import com.azure.spring.cloud.config.ConfigurationClientCustomizer;
 import com.azure.spring.cloud.config.implementation.properties.ConfigStore;
 import com.azure.spring.cloud.service.implementation.appconfiguration.ConfigurationClientProperties;
 
@@ -45,7 +45,7 @@ public class AppConfigurationReplicaClientBuilderTest {
     private TokenCredential credentialMock;
 
     @Mock
-    private ConfigurationClientBuilderSetup modifierMock;
+    private ConfigurationClientCustomizer modifierMock;
 
     AppConfigurationReplicaClientsBuilder clientBuilder;
 

--- a/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/config/implementation/stores/KeyVaultClientTest.java
+++ b/sdk/appconfiguration/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/config/implementation/stores/KeyVaultClientTest.java
@@ -53,27 +53,6 @@ public class KeyVaultClientTest {
     }
 
     @Test
-    public void multipleArguments() throws URISyntaxException {
-        String keyVaultUri = "https://keyvault.vault.azure.net";
-
-        KeyVaultCredentialProvider provider = new KeyVaultCredentialProvider() {
-
-            @Override
-            public TokenCredential getKeyVaultCredential(String uri) {
-                assertEquals("https://keyvault.vault.azure.net", uri);
-                return credentialMock;
-            }
-        };
-
-        clientStore = new AppConfigurationSecretClientManager(keyVaultUri, provider, null, null);
-
-        AppConfigurationSecretClientManager test = Mockito.spy(clientStore);
-        Mockito.doReturn(builderMock).when(test).getBuilder();
-
-        Assertions.assertThrows(IllegalArgumentException.class, test::build);
-    }
-
-    @Test
     public void configProviderAuth() throws URISyntaxException {
         String keyVaultUri = "https://keyvault.vault.azure.net";
 

--- a/sdk/spring/spring-cloud-azure-actuator-autoconfigure/pom.xml
+++ b/sdk/spring/spring-cloud-azure-actuator-autoconfigure/pom.xml
@@ -73,6 +73,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.azure.spring</groupId>
+      <artifactId>spring-cloud-azure-appconfiguration-config</artifactId>
+      <version>4.0.0-beta.1</version> <!-- {x-version-update;com.azure.spring:spring-cloud-azure-appconfiguration-config;dependency} -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs</artifactId>
       <version>5.14.0</version> <!-- {x-version-update;com.azure:azure-messaging-eventhubs;dependency} -->

--- a/sdk/spring/spring-cloud-azure-actuator-autoconfigure/src/main/java/com/azure/spring/cloud/actuator/autoconfigure/appconfiguration/AppConfigurationConfigHealthConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-actuator-autoconfigure/src/main/java/com/azure/spring/cloud/actuator/autoconfigure/appconfiguration/AppConfigurationConfigHealthConfiguration.java
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-package com.azure.spring.cloud.config.implementation.config;
+package com.azure.spring.cloud.actuator.autoconfigure.appconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -10,9 +10,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.azure.spring.cloud.actuator.appconfiguration.AppConfigurationConfigHealthIndicator;
 import com.azure.spring.cloud.config.AppConfigurationRefresh;
 import com.azure.spring.cloud.config.implementation.config.AppConfigurationAutoConfiguration.AppConfigurationWatchAutoConfiguration;
-import com.azure.spring.cloud.config.implementation.health.AppConfigurationHealthIndicator;
 
 /**
  * Health Indicator for Azure App Configuration store connections.
@@ -21,12 +21,12 @@ import com.azure.spring.cloud.config.implementation.health.AppConfigurationHealt
 @ConditionalOnClass({ HealthIndicator.class })
 @ConditionalOnEnabledHealthIndicator("azure-app-configuration")
 @AutoConfigureAfter(AppConfigurationWatchAutoConfiguration.class)
-public class AppConfigurationHealthAutoConfiguration {
+public class AppConfigurationConfigHealthConfiguration {
 
     @Bean
     @ConditionalOnBean(AppConfigurationRefresh.class)
-    AppConfigurationHealthIndicator appConfigurationHealthIndicator(AppConfigurationRefresh refresh) {
-        return new AppConfigurationHealthIndicator(refresh);
+    AppConfigurationConfigHealthIndicator appConfigurationHealthIndicator(AppConfigurationRefresh refresh) {
+        return new AppConfigurationConfigHealthIndicator(refresh);
     }
 
 }

--- a/sdk/spring/spring-cloud-azure-actuator/pom.xml
+++ b/sdk/spring/spring-cloud-azure-actuator/pom.xml
@@ -67,6 +67,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.azure.spring</groupId>
+      <artifactId>spring-cloud-azure-appconfiguration-config</artifactId>
+      <version>4.0.0-beta.1</version> <!-- {x-version-update;com.azure.spring:spring-cloud-azure-appconfiguration-config;dependency} -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs</artifactId>
       <version>5.14.0</version> <!-- {x-version-update;com.azure:azure-messaging-eventhubs;dependency} -->

--- a/sdk/spring/spring-cloud-azure-actuator/src/main/java/com/azure/spring/cloud/actuator/appconfiguration/AppConfigurationConfigHealthIndicator.java
+++ b/sdk/spring/spring-cloud-azure-actuator/src/main/java/com/azure/spring/cloud/actuator/appconfiguration/AppConfigurationConfigHealthIndicator.java
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-package com.azure.spring.cloud.config.implementation.health;
+package com.azure.spring.cloud.actuator.appconfiguration;
 
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 
 import com.azure.spring.cloud.config.AppConfigurationRefresh;
+import com.azure.spring.cloud.config.implementation.health.AppConfigurationStoreHealth;
 
 /**
  * Indicator class of App Configuration 
  */
-public final class AppConfigurationHealthIndicator implements HealthIndicator {
+public final class AppConfigurationConfigHealthIndicator implements HealthIndicator {
 
     private final AppConfigurationRefresh refresh;
 
@@ -18,7 +19,7 @@ public final class AppConfigurationHealthIndicator implements HealthIndicator {
      * Indicator for the Health endpoint for connections to App Configurations.
      * @param refresh App Configuration store refresher
      */
-    public AppConfigurationHealthIndicator(AppConfigurationRefresh refresh) {
+    public AppConfigurationConfigHealthIndicator(AppConfigurationRefresh refresh) {
         this.refresh = refresh;
     }
 

--- a/sdk/spring/spring-cloud-azure-actuator/src/test/java/com/azure/spring/cloud/actuator/appconfiguration/AppConfigurationConfigHealthIndicatorTest.java
+++ b/sdk/spring/spring-cloud-azure-actuator/src/test/java/com/azure/spring/cloud/actuator/appconfiguration/AppConfigurationConfigHealthIndicatorTest.java
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-package com.azure.spring.cloud.config.implementation;
+package com.azure.spring.cloud.actuator.appconfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -18,12 +18,11 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
 import com.azure.spring.cloud.config.AppConfigurationRefresh;
-import com.azure.spring.cloud.config.implementation.health.AppConfigurationHealthIndicator;
 import com.azure.spring.cloud.config.implementation.health.AppConfigurationStoreHealth;
 import com.azure.spring.cloud.config.implementation.properties.AppConfigurationProperties;
 import com.azure.spring.cloud.config.implementation.properties.ConfigStore;
 
-public class AppConfigurationHealthIndicatorTest {
+public class AppConfigurationConfigHealthIndicatorTest {
 
     @Mock
     private AppConfigurationRefresh refreshMock;
@@ -35,7 +34,7 @@ public class AppConfigurationHealthIndicatorTest {
 
     @Test
     public void noConfigurationStores() {
-        AppConfigurationHealthIndicator indicator = new AppConfigurationHealthIndicator(refreshMock);
+        AppConfigurationConfigHealthIndicator indicator = new AppConfigurationConfigHealthIndicator(refreshMock);
         Map<String, AppConfigurationStoreHealth> storeHealth = new HashMap<>();
 
         when(refreshMock.getAppConfigurationStoresHealth()).thenReturn(storeHealth);
@@ -49,7 +48,7 @@ public class AppConfigurationHealthIndicatorTest {
     public void heathlyConfigurationStore() {
         String storeName = "singleHealthyStoreIndicatorTest";
 
-        AppConfigurationHealthIndicator indicator = new AppConfigurationHealthIndicator(refreshMock);
+        AppConfigurationConfigHealthIndicator indicator = new AppConfigurationConfigHealthIndicator(refreshMock);
         Map<String, AppConfigurationStoreHealth> storeHealth = new HashMap<>();
 
         storeHealth.put(storeName, AppConfigurationStoreHealth.UP);
@@ -76,7 +75,7 @@ public class AppConfigurationHealthIndicatorTest {
 
         properties.setStores(stores);
 
-        AppConfigurationHealthIndicator indicator = new AppConfigurationHealthIndicator(refreshMock);
+        AppConfigurationConfigHealthIndicator indicator = new AppConfigurationConfigHealthIndicator(refreshMock);
 
         Map<String, AppConfigurationStoreHealth> mockHealth = new HashMap<>();
 
@@ -94,7 +93,7 @@ public class AppConfigurationHealthIndicatorTest {
     public void unheathlyConfigurationStore() {
         String storeName = "singleUnhealthyStoreIndicatorTest";
 
-        AppConfigurationHealthIndicator indicator = new AppConfigurationHealthIndicator(refreshMock);
+        AppConfigurationConfigHealthIndicator indicator = new AppConfigurationConfigHealthIndicator(refreshMock);
 
         Map<String, AppConfigurationStoreHealth> healthStatus = new HashMap<>();
 


### PR DESCRIPTION
# Description

* Moves Health to Spring Actuator/Actuator-Autoconfigure
* Renames ConfigurationClientBuilderSetup -> ConfigurationClientCustomizer
* Removes an old test that was breaking the build.
  * Managed Identity is no longer an option to provided via configuration. 